### PR TITLE
Print only files below the min coverage

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -30,6 +30,11 @@ class Plugin implements HandlesArguments
     private float $coverageMin = 0.0;
 
     /**
+     * Whether to only show errors.
+     */
+    private bool $errorsOnly = false;
+
+    /**
      * Creates a new Plugin instance.
      */
     public function __construct(
@@ -51,6 +56,10 @@ class Plugin implements HandlesArguments
             if (str_starts_with($argument, '--min')) {
                 // grab the value of the --min argument
                 $this->coverageMin = (float) explode('=', $argument)[1];
+            }
+
+            if ($argument === '--errors-only') {
+                $this->errorsOnly = true;
             }
         }
 
@@ -91,6 +100,10 @@ class Plugin implements HandlesArguments
                 $uncoveredLines = implode(', ', $uncoveredLines);
 
                 $totals[] = $percentage = $result->totalCoverage;
+
+                if ($this->errorsOnly && $percentage > $this->coverageMin) {
+                    return;
+                }
 
                 renderUsing($this->output);
                 render(<<<HTML

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -101,7 +101,7 @@ class Plugin implements HandlesArguments
 
                 $totals[] = $percentage = $result->totalCoverage;
 
-                if ($this->errorsOnly && $percentage > $this->coverageMin) {
+                if ($this->errorsOnly && $percentage >= $this->coverageMin) {
                     return;
                 }
 


### PR DESCRIPTION
This PR is adding a new `--errors-only` flag that when passed to the command call will print only the files that have a coverage below the value set in with the `--min` argument