### PR TITLE
feat: add ignore attribute

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.1",
-        "phpstan/phpstan": "^1.10.26",
+        "phpstan/phpstan": "^1.10.30",
         "tomasvotruba/type-coverage": "0.2.0",
         "pestphp/pest-plugin": "^2.0.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^8.1",
         "phpstan/phpstan": "^1.10.30",
-        "tomasvotruba/type-coverage": "0.2.0",
+        "tomasvotruba/type-coverage": "0.2.7",
         "pestphp/pest-plugin": "^2.0.1"
     },
     "autoload": {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -30,6 +30,13 @@ class Plugin implements HandlesArguments
     private float $coverageMin = 0.0;
 
     /**
+     * File patterns to  ignore.
+     *
+     * @var array<int, string>
+     */
+    private array $ignore = [];
+
+    /**
      * Creates a new Plugin instance.
      */
     public function __construct(
@@ -52,6 +59,13 @@ class Plugin implements HandlesArguments
                 // grab the value of the --min argument
                 $this->coverageMin = (float) explode('=', $argument)[1];
             }
+
+            if (str_starts_with($argument, '--ignore=')) {
+                $this->ignore = [
+                    ...$this->ignore,
+                    ...explode(',', explode('=', $argument, 2)[1]),
+                ];
+            }
         }
 
         $source = ConfigurationSourceDetector::detect();
@@ -65,7 +79,7 @@ class Plugin implements HandlesArguments
             $this->exit(1);
         }
 
-        $files = Finder::create()->in($source)->name('*.php')->files();
+        $files = Finder::create()->in($source)->name('*.php')->notPath($this->ignore)->files();
         $totals = [];
 
         $this->output->writeln(['']);

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -11,6 +11,7 @@ use Pest\TestSuite;
 use Pest\TypeCoverage\Support\ConfigurationSourceDetector;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Finder\Finder;
+
 use function Termwind\render;
 use function Termwind\renderUsing;
 use function Termwind\terminal;

--- a/src/TestCaseForTypeCoverage.php
+++ b/src/TestCaseForTypeCoverage.php
@@ -101,7 +101,7 @@ final class TestCaseForTypeCoverage extends RuleTestCase
         if ($analyserResult->getCollectedData() !== []) {
             $ruleRegistry = new DirectRegistry($this->getRules());
             $nodeType = CollectedDataNode::class;
-            $node = new CollectedDataNode($analyserResult->getCollectedData());
+            $node = new CollectedDataNode($analyserResult->getCollectedData(), true);
             $scopeFactory = $this->createScopeFactory($this->createReflectionProvider(), $this->getTypeSpecifier());
             $scope = $scopeFactory->create(ScopeContext::create('irrelevant'));
             foreach ($ruleRegistry->getRules($nodeType) as $rule) {

--- a/tests/Plugin.php
+++ b/tests/Plugin.php
@@ -22,3 +22,19 @@ test('output', function () {
             '.. pa12 83',
         );
 });
+
+test('ignore file pattern', function () {
+    $output = new BufferedOutput();
+    $plugin = new class($output) extends Plugin
+    {
+        public function exit(int $code): never
+        {
+            throw new Exception($code);
+        }
+    };
+
+    expect(fn () => $plugin->handleArguments(['--type-coverage', '--ignore=All.php']))->toThrow(Exception::class, 0)
+        ->and($output->fetch())->not->toContain(
+            'All.php',
+        );
+});


### PR DESCRIPTION
This PR allows to ignore certain files or paths from being tested.

```bash
# ignore a specific file
vendor/bin/pest --type-coverage --ignore=MyLegacyFile.php

# or a path
vendor/bin/pest --type-coverage --ignore=my/legacy/code

# or multiple files and paths
vendor/bin/pest --type-coverage --ignore=MyLegacyFile.php --ignore=AnotherFile.php --ignore=my/legacy/code

# or comma separated
vendor/bin/pest --type-coverage --ignore=MyLegacyFile.php,AnotherFile.php
```

This is helpful if you want to enforce a minimal coverage for new code in a legacy project:

```bash
vendor/bin/pest --type-coverage --min=100 --ignore=MyLegacyFile.php
```

There is already a different [PR](https://github.com/pestphp/pest-plugin-type-coverage/pull/5) which suggest to add an annotation to ignore individual lines from being tested, but for a legacy application I would prefer to ignore the whole files.