### PR TITLE
Fix phpstan incompatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.1",
-        "phpstan/phpstan": "^1.10.26",
+        "phpstan/phpstan": "^1.10.30",
         "tomasvotruba/type-coverage": "0.2.0",
         "pestphp/pest-plugin": "^2.0.1"
     },

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -11,6 +11,7 @@ use Pest\TestSuite;
 use Pest\TypeCoverage\Support\ConfigurationSourceDetector;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Finder\Finder;
+
 use function Termwind\render;
 use function Termwind\renderUsing;
 use function Termwind\terminal;

--- a/src/TestCaseForTypeCoverage.php
+++ b/src/TestCaseForTypeCoverage.php
@@ -101,7 +101,7 @@ final class TestCaseForTypeCoverage extends RuleTestCase
         if ($analyserResult->getCollectedData() !== []) {
             $ruleRegistry = new DirectRegistry($this->getRules());
             $nodeType = CollectedDataNode::class;
-            $node = new CollectedDataNode($analyserResult->getCollectedData());
+            $node = new CollectedDataNode($analyserResult->getCollectedData(), true);
             $scopeFactory = $this->createScopeFactory($this->createReflectionProvider(), $this->getTypeSpecifier());
             $scope = $scopeFactory->create(ScopeContext::create('irrelevant'));
             foreach ($ruleRegistry->getRules($nodeType) as $rule) {


### PR DESCRIPTION
Fixes https://github.com/pestphp/pest-plugin-type-coverage/issues/11

PHPStan has introduced BC in the latest version 1.10.30 on the `CollectedDataNode` constructor: https://github.com/phpstan/phpstan-src/commit/5f59d58b62ba130aaeedd7d804f3d0bb2b19e4fd#diff-af9341466859e16c919bb3ab633c1e2bd47ca7598f4ee3ac1b3385206c75be77L18