### PR TITLE
feat: add a output to the command line if ignored lines are present

### DIFF
--- a/src/Analyser.php
+++ b/src/Analyser.php
@@ -22,9 +22,9 @@ final class Analyser
         $testCase = new TestCaseForTypeCoverage();
 
         foreach ($files as $file) {
-            $errors = $testCase->gatherAnalyserErrors([$file]);
+            [$errors, $ignored] = $testCase->gatherAnalyserErrors([$file]);
 
-            $callback(Result::fromPHPStanErrors($file, $errors));
+            $callback(Result::fromPHPStanErrors($file, $errors, $ignored));
         }
     }
 }

--- a/src/Analyser.php
+++ b/src/Analyser.php
@@ -22,7 +22,9 @@ final class Analyser
         $testCase = new TestCaseForTypeCoverage();
 
         foreach ($files as $file) {
-            [$errors, $ignored] = $testCase->gatherAnalyserErrors([$file]);
+            $errors = $testCase->gatherAnalyserErrors([$file]);
+            $ignored = $testCase->getIgnoredErrors();
+            $testCase->resetIgnoredErrors();
 
             $callback(Result::fromPHPStanErrors($file, $errors, $ignored));
         }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -79,17 +79,33 @@ class Plugin implements HandlesArguments
                 $truncateAt = max(1, terminal()->width() - 12);
 
                 $uncoveredLines = [];
+                $uncoveredLinesIgnored = [];
 
                 $errors = $result->errors;
+                $errorsIgnored = $result->errorsIgnored;
 
-                usort($errors, fn (Error $a, Error $b): int => $a->line <=> $b->line);
+                usort($errors, static fn (Error $a, Error $b): int => $a->line <=> $b->line);
+                usort($errorsIgnored, static fn (Error $a, Error $b): int => $a->line <=> $b->line);
 
                 foreach ($errors as $error) {
                     $uncoveredLines[] = $error->getShortType().$error->line;
                 }
+                foreach ($errorsIgnored as $error) {
+                    $uncoveredLinesIgnored[] = $error->getShortType().$error->line;
+                }
 
                 $color = $uncoveredLines === [] ? 'green' : 'yellow';
+
                 $uncoveredLines = implode(', ', $uncoveredLines);
+                $uncoveredLinesIgnored = implode(', ', $uncoveredLinesIgnored);
+                // if there are uncovered lines, add a space before the ignored lines
+                // but only if there are ignored lines
+                if ($uncoveredLinesIgnored !== '') {
+                    $uncoveredLinesIgnored = '<span class="text-gray">'.$uncoveredLinesIgnored.'</span>';
+                    if ($uncoveredLines !== '') {
+                        $uncoveredLinesIgnored = ' '.$uncoveredLinesIgnored;
+                    }
+                }
 
                 $totals[] = $percentage = $result->totalCoverage;
 
@@ -98,7 +114,7 @@ class Plugin implements HandlesArguments
                 <div class="flex mx-2">
                     <span class="truncate-{$truncateAt}">{$path}</span>
                     <span class="flex-1 content-repeat-[.] text-gray mx-1"></span>
-                    <span class="text-{$color}">$uncoveredLines {$percentage}%</span>
+                    <span class="text-{$color}">$uncoveredLines{$uncoveredLinesIgnored} {$percentage}%</span>
                 </div>
                 HTML);
             },

--- a/src/Result.php
+++ b/src/Result.php
@@ -15,6 +15,7 @@ final class Result
      * Creates a new result instance.
      *
      * @param  array<int, Error>  $errors
+     * @param  array<int, Error>  $errorsIgnored
      */
     private function __construct(
         public readonly string $file,
@@ -32,7 +33,7 @@ final class Result
      * Creates a new result instance from the given PHPStan errors.
      *
      * @param  array<int, PHPStanError>  $phpstanErrors
-     * @param array<int, PHPStanError> $phpstanErrorsIgnored
+     * @param  array<int, PHPStanError>  $phpstanErrorsIgnored
      */
     public static function fromPHPStanErrors(string $file, array $phpstanErrors, array $phpstanErrorsIgnored): self
     {

--- a/src/TestCaseForTypeCoverage.php
+++ b/src/TestCaseForTypeCoverage.php
@@ -113,6 +113,7 @@ final class TestCaseForTypeCoverage extends RuleTestCase
                 foreach ($ruleErrors as $ruleError) {
                     if ($this->ignored($ruleError)) {
                         $ignoredErrors[] = $ruleErrorTransformer->transform($ruleError, $scope, $nodeType, $node->getLine());
+
                         continue;
                     }
 


### PR DESCRIPTION
When merge, this PR will do:
* add an output to the command line if ignored lines are present

The idea was to display any ignored types with this new helper released today.
It was a little tricky for me to store ignored letters. Maybe you don't like the implementation, there is a lot of duplicated code. But I think perhaps another contributor would like to take his time to review the idea.

I covered only the skipped ones in gray to display them as a background color but the whole line.

## Output

![CleanShot 2023-10-02 at 11 12 11](https://github.com/pestphp/pest-plugin-type-coverage/assets/60591772/64b8350e-95f1-4d71-80c9-1ecef2b5559e)

