### PR TITLE
Fix NodeScopeResolver parameters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.1",
-        "phpstan/phpstan": "^1.10.42",
+        "phpstan/phpstan": "^1.10.43",
         "tomasvotruba/type-coverage": "^0.2.1",
         "pestphp/pest-plugin": "^2.1.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.1",
-        "phpstan/phpstan": "^1.10.37",
+        "phpstan/phpstan": "^1.10.42",
         "tomasvotruba/type-coverage": "^0.2.1",
         "pestphp/pest-plugin": "^2.1.1"
     },

--- a/src/PHPStanAnalyser.php
+++ b/src/PHPStanAnalyser.php
@@ -17,6 +17,7 @@ use PHPStan\DependencyInjection\Reflection\ClassReflectionExtensionRegistryProvi
 use PHPStan\DependencyInjection\Type\DynamicThrowTypeExtensionProvider;
 use PHPStan\File\FileHelper;
 use PHPStan\Php\PhpVersion;
+use PHPStan\Reflection\SignatureMap\SignatureMapProvider;
 use PHPStan\PhpDoc\PhpDocInheritanceResolver;
 use PHPStan\PhpDoc\StubPhpDocProvider;
 use PHPStan\Reflection\InitializerExprTypeResolver;
@@ -56,6 +57,7 @@ final class PHPStanAnalyser
             $container->getByType(FileTypeMapper::class),
             $container->getByType(StubPhpDocProvider::class),
             $container->getByType(PhpVersion::class),
+            $container->getByType(SignatureMapProvider::class),
             $container->getByType(PhpDocInheritanceResolver::class),
             $container->getByType(FileHelper::class),
             $typeSpecifier, // @phpstan-ignore-line

--- a/src/PHPStanAnalyser.php
+++ b/src/PHPStanAnalyser.php
@@ -68,6 +68,7 @@ final class PHPStanAnalyser
             true,
             [],
             [],
+            [],
             true,
             true,
             false,

--- a/src/PHPStanAnalyser.php
+++ b/src/PHPStanAnalyser.php
@@ -17,11 +17,11 @@ use PHPStan\DependencyInjection\Reflection\ClassReflectionExtensionRegistryProvi
 use PHPStan\DependencyInjection\Type\DynamicThrowTypeExtensionProvider;
 use PHPStan\File\FileHelper;
 use PHPStan\Php\PhpVersion;
-use PHPStan\Reflection\SignatureMap\SignatureMapProvider;
 use PHPStan\PhpDoc\PhpDocInheritanceResolver;
 use PHPStan\PhpDoc\StubPhpDocProvider;
 use PHPStan\Reflection\InitializerExprTypeResolver;
 use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Reflection\SignatureMap\SignatureMapProvider;
 use PHPStan\Rules\DirectRegistry;
 use PHPStan\Rules\Properties\ReadWritePropertiesExtensionProvider;
 use PHPStan\Rules\Rule;


### PR DESCRIPTION
[phpstan/phpstan-src](https://github.com/phpstan/phpstan-src) `v1.10.42` have added a new argument of type `SignatureMapProvider` to `NodeScopeResolver` which causing this error when installing `pestphp/pest-plugin-type-coverage`.  Same thing for fourth last parameter which been added on `v1.10.43`. This must be fixed after merging this PR.

![Screenshot from 2023-11-18 23-10-42](https://github.com/pestphp/pest-plugin-type-coverage/assets/60013703/600070ba-8ee4-465e-aaec-16eeac10b1ea)
