### PR TITLE
fix: improve rounding for total coverage

### DIFF
--- a/src/Result.php
+++ b/src/Result.php
@@ -77,7 +77,7 @@ final class Result
             $propertyCoverage,
             $paramCoverage,
             $returnTypeCoverage,
-            (int) round(($propertyCoverage + $paramCoverage + $returnTypeCoverage) / 3),
+            (int) round(($propertyCoverage + $paramCoverage + $returnTypeCoverage) / 3, mode: PHP_ROUND_HALF_DOWN),
         );
     }
 }


### PR DESCRIPTION
This changes the rounding method when calculating the total type coverage. Previously, it was using the default of `PHP_ROUND_HALF_UP`, which rounds up when half way between numbers.