### PR TITLE
add option to hide files with 100% type coverage from output

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -34,6 +34,11 @@ class Plugin implements HandlesArguments
     private float $coverageMin = 0.0;
 
     /**
+     * Hide files with complete type coverage from output
+     */
+    private bool $hideComplete = false;
+
+    /**
      * The logger used to output type coverage to a file.
      */
     private Logger $coverageLogger;
@@ -106,6 +111,10 @@ class Plugin implements HandlesArguments
 
                 $this->coverageLogger = new JsonLogger(explode('=', $argument)[1], $this->coverageMin);
             }
+
+            if ($argument == '--hide-complete') {
+                $this->hideComplete = true;
+            }
         }
 
         $source = ConfigurationSourceDetector::detect();
@@ -164,14 +173,16 @@ class Plugin implements HandlesArguments
 
                 $totals[] = $percentage = $result->totalCoverage;
 
-                renderUsing($this->output);
-                render(<<<HTML
-                <div class="flex mx-2">
-                    <span class="truncate-{$truncateAt}">{$path}</span>
-                    <span class="flex-1 content-repeat-[.] text-gray mx-1"></span>
-                    <span class="text-{$color}">$uncoveredLines{$uncoveredLinesIgnored} {$percentage}%</span>
-                </div>
-                HTML);
+                if ($this->hideComplete === false || $percentage < 100) {
+                    renderUsing($this->output);
+                    render(<<<HTML
+                    <div class="flex mx-2">
+                        <span class="truncate-{$truncateAt}">{$path}</span>
+                        <span class="flex-1 content-repeat-[.] text-gray mx-1"></span>
+                        <span class="text-{$color}">$uncoveredLines{$uncoveredLinesIgnored} {$percentage}%</span>
+                    </div>
+                    HTML);
+                }
             },
         );
 

--- a/tests/Plugin.php
+++ b/tests/Plugin.php
@@ -23,6 +23,25 @@ test('output', function () {
         );
 });
 
+test('it only outputs files under 100% coverage', function () {
+    $output = new BufferedOutput();
+    $plugin = new class($output) extends Plugin
+    {
+        public function exit(int $code): never
+        {
+            throw new Exception($code);
+        }
+    };
+
+    expect(fn () => $plugin->handleArguments(['--type-coverage', '--hide-complete']))->toThrow(Exception::class, 0)
+        ->and($output->fetch())->toContain(
+            '.. pr12 83',
+            '.. pr12, pa14, pa14, rt14 0',
+            '.. rt12 67',
+            '.. pa12 83',
+        )->not->ToContain('.. 100%');
+});
+
 test('it can output to json', function () {
     $output = new BufferedOutput();
     $plugin = new class($output) extends Plugin


### PR DESCRIPTION
Including the option `--hide-complete` will hide the files with 100% coverage from the output. This makes it much easier to see which files still have missing type declarations. 

The files with 100% coverage are still included in the calculation of the total coverage percentage.

![Screenshot from 2024-01-12 16-53-34](https://github.com/pestphp/pest-plugin-type-coverage/assets/490893/69834130-6d62-430f-8e3e-0315edd05395)
