### PR TITLE
Fix NodeScopeResolver args for PHPStan v1.10.60

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.1",
-        "phpstan/phpstan": "^1.10.55",
+        "phpstan/phpstan": "^1.10.60",
         "tomasvotruba/type-coverage": "^0.2.1",
         "pestphp/pest-plugin": "^2.1.1"
     },

--- a/src/PHPStanAnalyser.php
+++ b/src/PHPStanAnalyser.php
@@ -72,6 +72,7 @@ final class PHPStanAnalyser
             true,
             true,
             false,
+            true,
         );
 
         $fileAnalyser = new FileAnalyser(


### PR DESCRIPTION
This PR fixes an error with the latest version of PHPStan v1.10.60

The change in PHPStan was introduced in this commit: https://github.com/phpstan/phpstan-src/commit/27a952e87aeca1f9aed387f7155d0f3b09c142de

We had a similar issue with PHPStan v1.10.43 before. See my PR from back then https://github.com/pestphp/pest-plugin-type-coverage/pull/17