### PR TITLE
Reworks for PHPStan 1.11.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.1",
-        "phpstan/phpstan": "^1.11.0",
+        "phpstan/phpstan": "^1.11.3",
         "tomasvotruba/type-coverage": "^0.2.8",
         "pestphp/pest-plugin": "^2.1.1"
     },

--- a/src/PHPStanAnalyser.php
+++ b/src/PHPStanAnalyser.php
@@ -16,6 +16,7 @@ use PHPStan\Dependency\DependencyResolver;
 use PHPStan\DependencyInjection\Container;
 use PHPStan\DependencyInjection\Reflection\ClassReflectionExtensionRegistryProvider;
 use PHPStan\DependencyInjection\Type\DynamicThrowTypeExtensionProvider;
+use PHPStan\DependencyInjection\Type\ParameterClosureTypeExtensionProvider;
 use PHPStan\File\FileHelper;
 use PHPStan\Php\PhpVersion;
 use PHPStan\PhpDoc\PhpDocInheritanceResolver;
@@ -64,6 +65,7 @@ final class PHPStanAnalyser
             $typeSpecifier, // @phpstan-ignore-line
             $container->getByType(DynamicThrowTypeExtensionProvider::class),
             $container->getByType(ReadWritePropertiesExtensionProvider::class),
+            $container->getByType(ParameterClosureTypeExtensionProvider::class),
             $scopeFactory,
             false,
             true,

--- a/tests/Plugin.php
+++ b/tests/Plugin.php
@@ -36,48 +36,13 @@ test('it can output to json', function () {
     expect(fn () => $plugin->handleArguments(['--type-coverage', '--type-coverage-json=test.json']))->toThrow(Exception::class, 0);
 
     expect(__DIR__.'/../test.json')->toBeReadableFile();
+
     expect(file_get_contents(__DIR__.'/../test.json'))->json()->toMatchArray([
         'format' => 'pest',
         'coverage-min' => 0,
         'result' => [
             [
-                'file' => 'src/PHPStanAnalyser.php',
-                'uncoveredLines' => [],
-                'uncoveredLinesIgnored' => [],
-                'percentage' => 100,
-            ],
-            [
                 'file' => 'src/TestCaseForTypeCoverage.php',
-                'uncoveredLines' => [],
-                'uncoveredLinesIgnored' => [],
-                'percentage' => 100,
-            ],
-            [
-                'file' => 'src/Contracts/Logger.php',
-                'uncoveredLines' => [],
-                'uncoveredLinesIgnored' => [],
-                'percentage' => 100,
-            ],
-            [
-                'file' => 'src/Plugin.php',
-                'uncoveredLines' => [],
-                'uncoveredLinesIgnored' => [],
-                'percentage' => 100,
-            ],
-            [
-                'file' => 'src/Result.php',
-                'uncoveredLines' => [],
-                'uncoveredLinesIgnored' => [],
-                'percentage' => 100,
-            ],
-            [
-                'file' => 'src/Error.php',
-                'uncoveredLines' => [],
-                'uncoveredLinesIgnored' => [],
-                'percentage' => 100,
-            ],
-            [
-                'file' => 'src/Support/ConfigurationSourceDetector.php',
                 'uncoveredLines' => [],
                 'uncoveredLinesIgnored' => [],
                 'percentage' => 100,
@@ -89,7 +54,19 @@ test('it can output to json', function () {
                 'percentage' => 100,
             ],
             [
-                'file' => 'src/Logging/NullLogger.php',
+                'file' => 'src/PHPStanAnalyser.php',
+                'uncoveredLines' => [],
+                'uncoveredLinesIgnored' => [],
+                'percentage' => 100,
+            ],
+            [
+                'file' => 'src/Support/ConfigurationSourceDetector.php',
+                'uncoveredLines' => [],
+                'uncoveredLinesIgnored' => [],
+                'percentage' => 100,
+            ],
+            [
+                'file' => 'src/Result.php',
                 'uncoveredLines' => [],
                 'uncoveredLinesIgnored' => [],
                 'percentage' => 100,
@@ -101,16 +78,40 @@ test('it can output to json', function () {
                 'percentage' => 100,
             ],
             [
-                'file' => 'tests/Fixtures/Properties.php',
-                'uncoveredLines' => ['pr12'],
+                'file' => 'src/Logging/NullLogger.php',
+                'uncoveredLines' => [],
+                'uncoveredLinesIgnored' => [],
+                'percentage' => 100,
+            ],
+            [
+                'file' => 'src/Contracts/Logger.php',
+                'uncoveredLines' => [],
+                'uncoveredLinesIgnored' => [],
+                'percentage' => 100,
+            ],
+            [
+                'file' => 'src/Error.php',
+                'uncoveredLines' => [],
+                'uncoveredLinesIgnored' => [],
+                'percentage' => 100,
+            ],
+            [
+                'file' => 'src/Plugin.php',
+                'uncoveredLines' => [],
+                'uncoveredLinesIgnored' => [],
+                'percentage' => 100,
+            ],
+            [
+                'file' => 'tests/Fixtures/Parameters.php',
+                'uncoveredLines' => ['pa12'],
                 'uncoveredLinesIgnored' => [],
                 'percentage' => 83,
             ],
             [
-                'file' => 'tests/Fixtures/All.php',
-                'uncoveredLines' => ['pr12', 'pa14', 'pa14', 'rt14'],
+                'file' => 'tests/Fixtures/Properties.php',
+                'uncoveredLines' => ['pr12'],
                 'uncoveredLinesIgnored' => [],
-                'percentage' => 0,
+                'percentage' => 83,
             ],
             [
                 'file' => 'tests/Fixtures/ReturnType.php',
@@ -119,10 +120,10 @@ test('it can output to json', function () {
                 'percentage' => 67,
             ],
             [
-                'file' => 'tests/Fixtures/Parameters.php',
-                'uncoveredLines' => ['pa12'],
+                'file' => 'tests/Fixtures/All.php',
+                'uncoveredLines' => ['pr12', 'pa14', 'pa14', 'rt14'],
                 'uncoveredLinesIgnored' => [],
-                'percentage' => 83,
+                'percentage' => 0,
             ],
         ],
         'total' => 88.07,


### PR DESCRIPTION
`PHPStan\Analyser\NodeScopeResolver` requires a `ParameterClosureTypeExtensionProvider` parameter that was not being passed. This PR adds this parameter and adjusts the tests.

It would be good if you could review the `it can output to json` test that I modified in `tests/Plugin.php`, as I'm not very sure if it is correct.

---
https://github.com/phpstan/phpstan/releases/tag/1.11.3