### PR TITLE
Fix: Update NodeScopeResolver Constructor Call to Match Latest PHPStan Version

### DIFF
--- a/src/PHPStanAnalyser.php
+++ b/src/PHPStanAnalyser.php
@@ -79,6 +79,7 @@ final class PHPStanAnalyser
             false,
             true,
             false,
+            false
         );
 
         $fileAnalyser = new FileAnalyser(


### PR DESCRIPTION
#### Problem
The code was encountering an error due to a mismatch in the number of arguments passed to the `NodeScopeResolver::__construct()` method. The latest version of PHPStan expects 24 arguments, but only 23 were provided, leading to a failure when running type coverage checks.

#### Solution
This PR updates the constructor call for `NodeScopeResolver` in the `PHPStanAnalyser::make` method to include the additional parameter required by the latest PHPStan version. The new parameter has been added with a default value (set to `false`), aligning with the latest method signature.