### PR TITLE
Fix: Argument #20 ($polluteScopeWithBlock) must be of type bool error

### DIFF
--- a/src/PHPStanAnalyser.php
+++ b/src/PHPStanAnalyser.php
@@ -71,15 +71,12 @@ final class PHPStanAnalyser
             $scopeFactory,
             false,
             true,
+            true,
             [],
             [],
             [],
             true,
             true,
-            false,
-            true,
-            false,
-            false,
         );
 
         $fileAnalyser = new FileAnalyser(

--- a/src/PHPStanAnalyser.php
+++ b/src/PHPStanAnalyser.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pest\TypeCoverage;
 
+use Composer\InstalledVersions;
 use PhpParser\Node;
 use PHPStan\Analyser\Analyser;
 use PHPStan\Analyser\FileAnalyser;
@@ -51,33 +52,67 @@ final class PHPStanAnalyser
 
         $scopeFactory = TestCaseForTypeCoverage::createScopeFactory($reflectionProvider, $typeSpecifier); // @phpstan-ignore-line
 
-        $nodeScopeResolver = new NodeScopeResolver(
-            $reflectionProvider,
-            $container->getByType(InitializerExprTypeResolver::class),
-            $container->getService('betterReflectionReflector'), // @phpstan-ignore-line
-            $container->getByType(ClassReflectionExtensionRegistryProvider::class),
-            $container->getByType(ParameterOutTypeExtensionProvider::class),
-            $container->getService('defaultAnalysisParser'), // @phpstan-ignore-line
-            $container->getByType(FileTypeMapper::class),
-            $container->getByType(StubPhpDocProvider::class),
-            $container->getByType(PhpVersion::class),
-            $container->getByType(SignatureMapProvider::class),
-            $container->getByType(PhpDocInheritanceResolver::class),
-            $container->getByType(FileHelper::class),
-            $typeSpecifier, // @phpstan-ignore-line
-            $container->getByType(DynamicThrowTypeExtensionProvider::class),
-            $container->getByType(ReadWritePropertiesExtensionProvider::class),
-            $container->getByType(ParameterClosureTypeExtensionProvider::class),
-            $scopeFactory,
-            false,
-            true,
-            true,
-            [],
-            [],
-            [],
-            true,
-            true,
-        );
+        $version = InstalledVersions::getPrettyVersion('phpstan/phpstan');
+        if (mb_strpos($version, '2.') === 0) {
+            $nodeScopeResolver = new NodeScopeResolver(
+                $reflectionProvider,
+                $container->getByType(InitializerExprTypeResolver::class),
+                $container->getService('betterReflectionReflector'), // @phpstan-ignore-line
+                $container->getByType(ClassReflectionExtensionRegistryProvider::class),
+                $container->getByType(ParameterOutTypeExtensionProvider::class),
+                $container->getService('defaultAnalysisParser'), // @phpstan-ignore-line
+                $container->getByType(FileTypeMapper::class),
+                $container->getByType(StubPhpDocProvider::class),
+                $container->getByType(PhpVersion::class),
+                $container->getByType(SignatureMapProvider::class),
+                $container->getByType(PhpDocInheritanceResolver::class),
+                $container->getByType(FileHelper::class),
+                $typeSpecifier, // @phpstan-ignore-line
+                $container->getByType(DynamicThrowTypeExtensionProvider::class),
+                $container->getByType(ReadWritePropertiesExtensionProvider::class),
+                $container->getByType(ParameterClosureTypeExtensionProvider::class),
+                $scopeFactory,
+                false,
+                true,
+                true,
+                [],
+                [],
+                [],
+                true,
+                true,
+            );
+        } else {
+            $nodeScopeResolver = new NodeScopeResolver(
+                $reflectionProvider,
+                $container->getByType(InitializerExprTypeResolver::class),
+                $container->getService('betterReflectionReflector'), // @phpstan-ignore-line
+                $container->getByType(ClassReflectionExtensionRegistryProvider::class),
+                $container->getByType(ParameterOutTypeExtensionProvider::class),
+                $container->getService('defaultAnalysisParser'), // @phpstan-ignore-line
+                $container->getByType(FileTypeMapper::class),
+                $container->getByType(StubPhpDocProvider::class),
+                $container->getByType(PhpVersion::class),
+                $container->getByType(SignatureMapProvider::class),
+                $container->getByType(PhpDocInheritanceResolver::class),
+                $container->getByType(FileHelper::class),
+                $typeSpecifier, // @phpstan-ignore-line
+                $container->getByType(DynamicThrowTypeExtensionProvider::class),
+                $container->getByType(ReadWritePropertiesExtensionProvider::class),
+                $container->getByType(ParameterClosureTypeExtensionProvider::class),
+                $scopeFactory,
+                false,
+                true,
+                [],
+                [],
+                [],
+                true,
+                true,
+                false,
+                true,
+                false,
+                false,
+            );
+        }
 
         $fileAnalyser = new FileAnalyser(
             $scopeFactory,


### PR DESCRIPTION
Based on [this](https://github.com/phpstan/phpstan-src/blob/2.0.x/src/Analyser/NodeScopeResolver.php#L258C3-L258C48) it accepts 25 arguments in the constructor but we are passing 28 (as per [1.x](https://github.com/phpstan/phpstan-src/blob/1.12.x/src/Analyser/NodeScopeResolver.php#L262)) right now. and the 20th argument is bool but we are passing an array. 

Therefore in this PR, I put true on the 20th argument and shifted other arguments +1 then removed arguments after the 25th argument same as a diff between [1.x](https://github.com/phpstan/phpstan-src/blob/1.12.x/src/Analyser/NodeScopeResolver.php#L262) and [2.x](https://github.com/phpstan/phpstan-src/blob/2.0.x/src/Analyser/NodeScopeResolver.php#L258C3-L258C48) PHPStan.

[this](https://github.com/MrPunyapal/basic-crud/actions/runs/12331578122/job/34418361358?pr=57) is not working and after these changes, it worked locally as expected you can see the screenshot below.
![image](https://github.com/user-attachments/assets/46f27844-a1ef-4e8a-8a5a-8ba0a850991d)
