### PR TITLE
chore: taking version from phpstan-src if it returns null.

### DIFF
--- a/src/PHPStanAnalyser.php
+++ b/src/PHPStanAnalyser.php
@@ -52,7 +52,7 @@ final class PHPStanAnalyser
 
         $scopeFactory = TestCaseForTypeCoverage::createScopeFactory($reflectionProvider, $typeSpecifier); // @phpstan-ignore-line
 
-        $version = InstalledVersions::getPrettyVersion('phpstan/phpstan');
+        $version = InstalledVersions::getPrettyVersion('phpstan/phpstan') ?? InstalledVersions::getPrettyVersion('phpstan/phpstan-src');
         if ($version !== null && mb_strpos($version, '2.') === 0) {
             $nodeScopeResolver = new NodeScopeResolver( // @phpstan-ignore-line
                 $reflectionProvider,


### PR DESCRIPTION
I find it locally sometimes it returns null even phpstan is installed. then I tried getting phpstan-src and it worked so added it with null coalescing operator.