### PR TITLE
Added handling for `--compact` parameter

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -39,6 +39,11 @@ class Plugin implements HandlesArguments
     private Logger $coverageLogger;
 
     /**
+     * Whether to use compact output.
+     */
+    private bool $compact = false;
+
+    /**
      * Creates a new Plugin instance.
      */
     public function __construct(
@@ -106,6 +111,10 @@ class Plugin implements HandlesArguments
 
                 $this->coverageLogger = new JsonLogger(explode('=', $argument)[1], $this->coverageMin);
             }
+
+            if (str_starts_with($argument, '--compact')) {
+                $this->compact = true;
+            }
         }
 
         $source = ConfigurationSourceDetector::detect();
@@ -145,6 +154,10 @@ class Plugin implements HandlesArguments
                 }
                 foreach ($errorsIgnored as $error) {
                     $uncoveredLinesIgnored[] = $error->getShortType().$error->line;
+                }
+
+                if ($this->compact && $uncoveredLines === []) {
+                    return;
                 }
 
                 $color = $uncoveredLines === [] ? 'green' : 'yellow';

--- a/tests/Plugin.php
+++ b/tests/Plugin.php
@@ -41,7 +41,7 @@ test('output with --compact', function () {
             '.. co14 87',
             '.. rt12 75',
             '.. pa12 87',
-        );
+        )->not->toContain('.. 100%');
 });
 
 test('it can output to json', function () {

--- a/tests/Plugin.php
+++ b/tests/Plugin.php
@@ -24,6 +24,26 @@ test('output', function () {
         );
 });
 
+test('output with --compact', function () {
+    $output = new BufferedOutput;
+    $plugin = new class($output) extends Plugin
+    {
+        public function exit(int $code): never
+        {
+            throw new Exception($code);
+        }
+    };
+
+    expect(fn () => $plugin->handleArguments(['--type-coverage', '--compact']))->toThrow(Exception::class, 0)
+        ->and($output->fetch())->toContain(
+            '.. pr12 87',
+            '.. co14, pr16, pa18, pa18, rt18 12',
+            '.. co14 87',
+            '.. rt12 75',
+            '.. pa12 87',
+        );
+});
+
 test('it can output to json', function () {
     $output = new BufferedOutput;
     $plugin = new class($output) extends Plugin


### PR DESCRIPTION
This PR adds the functionality of handling `--compact` CLI parameter.

When the parameter is passed to the plugin it skips the output of files with 100% coverage.

A test for the feature was also added.