### PR TITLE
Fix: Argument #11 ($attributeReflectionFactory) must be of type AttributeReflectionFactory

### DIFF
--- a/src/PHPStanAnalyser.php
+++ b/src/PHPStanAnalyser.php
@@ -23,6 +23,7 @@ use PHPStan\File\FileHelper;
 use PHPStan\Php\PhpVersion;
 use PHPStan\PhpDoc\PhpDocInheritanceResolver;
 use PHPStan\PhpDoc\StubPhpDocProvider;
+use PHPStan\Reflection\AttributeReflectionFactory;
 use PHPStan\Reflection\InitializerExprTypeResolver;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Reflection\SignatureMap\SignatureMapProvider;
@@ -53,7 +54,36 @@ final class PHPStanAnalyser
         $scopeFactory = TestCaseForTypeCoverage::createScopeFactory($reflectionProvider, $typeSpecifier); // @phpstan-ignore-line
 
         $version = InstalledVersions::getPrettyVersion('phpstan/phpstan') ?? InstalledVersions::getPrettyVersion('phpstan/phpstan-src');
-        if ($version !== null && mb_strpos($version, '2.') === 0) {
+        if ($version !== null && version_compare($version, '2.1.3', '>=')) {
+            $nodeScopeResolver = new NodeScopeResolver( // @phpstan-ignore-line
+                $reflectionProvider,
+                $container->getByType(InitializerExprTypeResolver::class),
+                $container->getService('betterReflectionReflector'), // @phpstan-ignore-line
+                $container->getByType(ClassReflectionExtensionRegistryProvider::class),
+                $container->getByType(ParameterOutTypeExtensionProvider::class),
+                $container->getService('defaultAnalysisParser'), // @phpstan-ignore-line
+                $container->getByType(FileTypeMapper::class),
+                $container->getByType(StubPhpDocProvider::class),
+                $container->getByType(PhpVersion::class),
+                $container->getByType(SignatureMapProvider::class),
+                $container->getByType(AttributeReflectionFactory::class),
+                $container->getByType(PhpDocInheritanceResolver::class),
+                $container->getByType(FileHelper::class),
+                $typeSpecifier, // @phpstan-ignore-line
+                $container->getByType(DynamicThrowTypeExtensionProvider::class),
+                $container->getByType(ReadWritePropertiesExtensionProvider::class),
+                $container->getByType(ParameterClosureTypeExtensionProvider::class),
+                $scopeFactory,
+                false,
+                true,
+                true, // @phpstan-ignore-line
+                [],
+                [],
+                [], // @phpstan-ignore-line
+                true,
+                true,
+            );
+        } elseif ($version !== null && version_compare($version, '2.0.0', '>=')) {
             $nodeScopeResolver = new NodeScopeResolver( // @phpstan-ignore-line
                 $reflectionProvider,
                 $container->getByType(InitializerExprTypeResolver::class),


### PR DESCRIPTION
[This commit](https://github.com/phpstan/phpstan-src/commit/a387fa32788fd38bc35313558f6e6a46fc2c451c) of [PHPStan 2.1.3](https://github.com/phpstan/phpstan/releases/tag/2.1.3) has added a new parameter to `NodeScopeResolver` constructor. This PR fixes the argument passing for PHPStan >= 2.1.3.

<img width="1167" alt="phpstan-2 1 3" src="https://github.com/user-attachments/assets/d740fba7-e1a9-4ba1-88e6-90dd46c223fe" />