### PR TITLE
Fix coverage result for 99.95%+

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -184,7 +184,7 @@ class Plugin implements HandlesArguments
         if ($exitCode === 1) {
             View::render('components.badge', [
                 'type' => 'ERROR',
-                'content' => 'Type coverage below expected: '.number_format($coverage, 1).'%. Minimum: '.number_format($this->coverageMin, 1).'%',
+                'content' => 'Type coverage below expected: '.number_format(floor($coverage * 10) / 10, 1).'%. Minimum: '.number_format($this->coverageMin, 1).'%',
             ]);
         } else {
             $totalCoverageAsString = $coverage === 0

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -184,7 +184,7 @@ class Plugin implements HandlesArguments
         if ($exitCode === 1) {
             View::render('components.badge', [
                 'type' => 'ERROR',
-                'content' => 'Type coverage below expected: '.number_format(floor($coverage * 10) / 10, 1).'%. Minimum: '.number_format($this->coverageMin, 1).'%',
+                'content' => 'Type coverage below expected: '.number_format($this->coverageMin, 1).'%, currently '.number_format(floor($coverage * 10) / 10, 1).'%',
             ]);
         } else {
             $totalCoverageAsString = $coverage === 0


### PR DESCRIPTION
I introduced a similar fix into PestPHP itself - https://github.com/pestphp/pest/pull/1207

If your coverage is 99.95%+, it outputs as being at 100%:

<img width="982" alt="Screenshot 2025-02-16 at 12 21 26" src="https://github.com/user-attachments/assets/fcb1f853-e5b6-461b-b095-d925e6da9ea6" />

But with this PR:

<img width="982" alt="Screenshot 2025-02-16 at 12 24 21" src="https://github.com/user-attachments/assets/27d2a78a-1901-4402-8cb2-8893eb746fa8" />

I then re-read the message and realised the variables are the wrong way round, I'm not expecting it to be 99.9%, I'm expecting it to be 100% and it's _currently_ 99.9.% I've instead made it consistent with PestPHP wording, so it's now:

<img width="982" alt="Screenshot 2025-02-16 at 12 31 01" src="https://github.com/user-attachments/assets/cd233e02-2596-408d-b2e1-34caf9f4db0b" />

