### PR TITLE
Feat: Validate --min option value

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -66,6 +66,17 @@ class Plugin implements HandlesArguments
 
         foreach ($arguments as $argument) {
             if (str_starts_with($argument, '--min')) {
+                $coverageMin = explode('=', $argument)[1];
+
+                if (! is_numeric($coverageMin) || (float) $coverageMin < 0 || (float) $coverageMin > 100) {
+                    View::render('components.badge', [
+                        'type' => 'ERROR',
+                        'content' => 'Invalid coverage min: '.$coverageMin,
+                    ]);
+
+                    $this->exit(1);
+                }
+
                 // grab the value of the --min argument
                 $this->coverageMin = (float) explode('=', $argument)[1];
             }


### PR DESCRIPTION
This PR adds checking the provided value for the `--min` option. It should be:

- Numeric
- Greater than or equal to 0
- Less than or equal to 100

Without checking this value, any value can be passed. For example, you can set `--min=200` and you'll see the following error:

<img width="1392" alt="Screenshot 1403-12-14 at 13 00 03" src="https://github.com/user-attachments/assets/128ff247-6b9c-42bd-80b4-00edd5babe40" />

Or you can pass any string like `--min=string`, and the casted value to `float` will be `0`.

After merging this PR, these cases will give an error:

<img width="777" alt="Screenshot 1403-12-14 at 13 00 12" src="https://github.com/user-attachments/assets/dd48935e-50d7-40bf-ad56-58c5696adf7f" />