### PR TITLE
fix: Refactor FileAnalyser instantiation with named arguments

### DIFF
--- a/src/PHPStanAnalyser.php
+++ b/src/PHPStanAnalyser.php
@@ -8,6 +8,7 @@ use Composer\InstalledVersions;
 use PhpParser\Node;
 use PHPStan\Analyser\Analyser;
 use PHPStan\Analyser\FileAnalyser;
+use PHPStan\Analyser\IgnoreErrorExtensionProvider;
 use PHPStan\Analyser\LocalIgnoresProcessor;
 use PHPStan\Analyser\NodeScopeResolver;
 use PHPStan\Analyser\RuleErrorTransformer;
@@ -145,12 +146,13 @@ final class PHPStanAnalyser
         }
 
         $fileAnalyser = new FileAnalyser(
-            $scopeFactory,
-            $nodeScopeResolver,
-            $container->getService('defaultAnalysisParser'), // @phpstan-ignore-line
-            $container->getByType(DependencyResolver::class),
-            new RuleErrorTransformer,
-            $container->getByType(LocalIgnoresProcessor::class),
+            scopeFactory: $scopeFactory,
+            nodeScopeResolver: $nodeScopeResolver,
+            parser: $container->getService('defaultAnalysisParser'), // @phpstan-ignore-line
+            dependencyResolver: $container->getByType(DependencyResolver::class),
+            ignoreErrorExtensionProvider: $container->getByType(IgnoreErrorExtensionProvider::class),
+            ruleErrorTransformer: new RuleErrorTransformer,
+            localIgnoresProcessor: $container->getByType(LocalIgnoresProcessor::class),
         );
 
         return new Analyser($fileAnalyser, $ruleRegistry, $collectorRegistry, $nodeScopeResolver, 9_999_999_999_999);


### PR DESCRIPTION
This pull request includes a few updates to the `PHPStanAnalyser.php` file to enhance dependency injection and improve code readability. The most important changes include the addition of a new import and the refactoring of the `FileAnalyser` instantiation to use named parameters.

Dependency Injection and Code Readability Improvements:

* [`src/PHPStanAnalyser.php`](diffhunk://#diff-219a7a176fba4ebb8784b3ab166ea691d1493dc66f5c98b7ffc324cc2d3639f9R11): Added the `IgnoreErrorExtensionProvider` import to support the new dependency injection.
* `public static function make(Container $container, array $rules, array $collector` in `src/PHPStanAnalyser.php`: Refactored the `FileAnalyser` instantiation to use named parameters, including the new `ignoreErrorExtensionProvider` dependency.

![Xnip2025-03-05_23-27-20](https://github.com/user-attachments/assets/cbfa169a-2997-42a2-9e73-8e01774e432a)

