### PR TITLE
Add support for IgnoreErrorExtensionProvider in PHPStanAnalyser

### DIFF
--- a/src/PHPStanAnalyser.php
+++ b/src/PHPStanAnalyser.php
@@ -8,6 +8,7 @@ use Composer\InstalledVersions;
 use PhpParser\Node;
 use PHPStan\Analyser\Analyser;
 use PHPStan\Analyser\FileAnalyser;
+use PHPStan\Analyser\IgnoreErrorExtensionProvider;
 use PHPStan\Analyser\LocalIgnoresProcessor;
 use PHPStan\Analyser\NodeScopeResolver;
 use PHPStan\Analyser\RuleErrorTransformer;
@@ -149,6 +150,7 @@ final class PHPStanAnalyser
             $nodeScopeResolver,
             $container->getService('defaultAnalysisParser'), // @phpstan-ignore-line
             $container->getByType(DependencyResolver::class),
+            $container->getByType(IgnoreErrorExtensionProvider::class),
             new RuleErrorTransformer,
             $container->getByType(LocalIgnoresProcessor::class),
         );


### PR DESCRIPTION
This PR introduces support for the newly added IgnoreErrorExtensionProvider in PHPStan 2.1.7, enhancing error handling during static analysis.