### PR TITLE
feat: add support for phpstan>=2.1.12

### DIFF
--- a/src/PHPStanAnalyser.php
+++ b/src/PHPStanAnalyser.php
@@ -25,6 +25,7 @@ use PHPStan\Php\PhpVersion;
 use PHPStan\PhpDoc\PhpDocInheritanceResolver;
 use PHPStan\PhpDoc\StubPhpDocProvider;
 use PHPStan\Reflection\AttributeReflectionFactory;
+use PHPStan\Reflection\Deprecation\DeprecationProvider;
 use PHPStan\Reflection\InitializerExprTypeResolver;
 use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Reflection\SignatureMap\SignatureMapProvider;
@@ -55,7 +56,37 @@ final class PHPStanAnalyser
         $scopeFactory = TestCaseForTypeCoverage::createScopeFactory($reflectionProvider, $typeSpecifier); // @phpstan-ignore-line
 
         $version = InstalledVersions::getPrettyVersion('phpstan/phpstan') ?? InstalledVersions::getPrettyVersion('phpstan/phpstan-src');
-        if ($version !== null && version_compare($version, '2.1.3', '>=')) {
+        if ($version !== null && version_compare($version, '2.1.12', '>=')) {
+            $nodeScopeResolver = new NodeScopeResolver( // @phpstan-ignore-line
+                $reflectionProvider,
+                $container->getByType(InitializerExprTypeResolver::class),
+                $container->getService('betterReflectionReflector'), // @phpstan-ignore-line
+                $container->getByType(ClassReflectionExtensionRegistryProvider::class),
+                $container->getByType(ParameterOutTypeExtensionProvider::class),
+                $container->getService('defaultAnalysisParser'), // @phpstan-ignore-line
+                $container->getByType(FileTypeMapper::class),
+                $container->getByType(StubPhpDocProvider::class),
+                $container->getByType(PhpVersion::class),
+                $container->getByType(SignatureMapProvider::class),
+                $container->getByType(DeprecationProvider::class),
+                $container->getByType(AttributeReflectionFactory::class),
+                $container->getByType(PhpDocInheritanceResolver::class),
+                $container->getByType(FileHelper::class),
+                $typeSpecifier, // @phpstan-ignore-line
+                $container->getByType(DynamicThrowTypeExtensionProvider::class),
+                $container->getByType(ReadWritePropertiesExtensionProvider::class),
+                $container->getByType(ParameterClosureTypeExtensionProvider::class),
+                $scopeFactory,
+                false,
+                true,
+                true, // @phpstan-ignore-line
+                [],
+                [],
+                [], // @phpstan-ignore-line
+                true,
+                true,
+            );
+        } elseif ($version !== null && version_compare($version, '2.1.3', '>=')) {
             $nodeScopeResolver = new NodeScopeResolver( // @phpstan-ignore-line
                 $reflectionProvider,
                 $container->getByType(InitializerExprTypeResolver::class),

--- a/src/PHPStanAnalyser.php
+++ b/src/PHPStanAnalyser.php
@@ -27,20 +27,12 @@ final class PHPStanAnalyser
      */
     public static function make(Container $container, array $rules, array $collectors): Analyser
     {
-        // Create registries for rules and collectors
-        $ruleRegistry = new DirectRegistry($rules);
-        $collectorRegistry = new Registry($collectors);
-
-        // Get required services from container
-        $nodeScopeResolver = $container->getByType(NodeScopeResolver::class);
-        $fileAnalyser = $container->getByType(FileAnalyser::class);
-
         return new Analyser(
-            $fileAnalyser,
-            $ruleRegistry,
-            $collectorRegistry,
-            $nodeScopeResolver,
-            9_999_999_999_999
+            fileAnalyser: $container->getByType(FileAnalyser::class),
+            ruleRegistry: new DirectRegistry($rules),
+            collectorRegistry: new Registry($collectors),
+            nodeScopeResolver: $container->getByType(NodeScopeResolver::class),
+            internalErrorsCountLimit: 9_999_999_999_999
         );
     }
 }

--- a/src/PHPStanAnalyser.php
+++ b/src/PHPStanAnalyser.php
@@ -20,27 +20,19 @@ use PHPStan\Rules\Rule;
 final class PHPStanAnalyser
 {
     /**
-     * Creates an analyser with the rules and collectors needed for type coverage.
+     * Creates an analyzer with the rules and collectors needed for type coverage.
      *
      * @param  array<int, Rule>  $rules
      * @param  array<int, Collector<Node, mixed>>  $collectors
      */
     public static function make(Container $container, array $rules, array $collectors): Analyser
     {
-        // Create registries for rules and collectors
-        $ruleRegistry = new DirectRegistry($rules);
-        $collectorRegistry = new Registry($collectors);
-
-        // Get required services from container
-        $nodeScopeResolver = $container->getByType(NodeScopeResolver::class);
-        $fileAnalyser = $container->getByType(FileAnalyser::class);
-
         return new Analyser(
-            $fileAnalyser,
-            $ruleRegistry,
-            $collectorRegistry,
-            $nodeScopeResolver,
-            9_999_999_999_999
+            fileAnalyser: $container->getByType(FileAnalyser::class),
+            ruleRegistry: new DirectRegistry($rules),
+            collectorRegistry: new Registry($collectors),
+            nodeScopeResolver: $container->getByType(NodeScopeResolver::class),
+            internalErrorsCountLimit: 9_999_999_999_999
         );
     }
 }

--- a/src/PHPStanAnalyser.php
+++ b/src/PHPStanAnalyser.php
@@ -4,35 +4,15 @@ declare(strict_types=1);
 
 namespace Pest\TypeCoverage;
 
-use Composer\InstalledVersions;
 use PhpParser\Node;
 use PHPStan\Analyser\Analyser;
 use PHPStan\Analyser\FileAnalyser;
-use PHPStan\Analyser\IgnoreErrorExtensionProvider;
-use PHPStan\Analyser\LocalIgnoresProcessor;
 use PHPStan\Analyser\NodeScopeResolver;
-use PHPStan\Analyser\RuleErrorTransformer;
 use PHPStan\Collectors\Collector;
 use PHPStan\Collectors\Registry;
-use PHPStan\Dependency\DependencyResolver;
 use PHPStan\DependencyInjection\Container;
-use PHPStan\DependencyInjection\Reflection\ClassReflectionExtensionRegistryProvider;
-use PHPStan\DependencyInjection\Type\DynamicThrowTypeExtensionProvider;
-use PHPStan\DependencyInjection\Type\ParameterClosureTypeExtensionProvider;
-use PHPStan\DependencyInjection\Type\ParameterOutTypeExtensionProvider;
-use PHPStan\File\FileHelper;
-use PHPStan\Php\PhpVersion;
-use PHPStan\PhpDoc\PhpDocInheritanceResolver;
-use PHPStan\PhpDoc\StubPhpDocProvider;
-use PHPStan\Reflection\AttributeReflectionFactory;
-use PHPStan\Reflection\Deprecation\DeprecationProvider;
-use PHPStan\Reflection\InitializerExprTypeResolver;
-use PHPStan\Reflection\ReflectionProvider;
-use PHPStan\Reflection\SignatureMap\SignatureMapProvider;
 use PHPStan\Rules\DirectRegistry;
-use PHPStan\Rules\Properties\ReadWritePropertiesExtensionProvider;
 use PHPStan\Rules\Rule;
-use PHPStan\Type\FileTypeMapper;
 
 /**
  * @internal
@@ -47,157 +27,20 @@ final class PHPStanAnalyser
      */
     public static function make(Container $container, array $rules, array $collectors): Analyser
     {
+        // Create registries for rules and collectors
         $ruleRegistry = new DirectRegistry($rules);
         $collectorRegistry = new Registry($collectors);
 
-        $reflectionProvider = $container->getByType(ReflectionProvider::class);
-        $typeSpecifier = $container->getService('typeSpecifier');
+        // Get required services from container
+        $nodeScopeResolver = $container->getByType(NodeScopeResolver::class);
+        $fileAnalyser = $container->getByType(FileAnalyser::class);
 
-        $scopeFactory = TestCaseForTypeCoverage::createScopeFactory($reflectionProvider, $typeSpecifier); // @phpstan-ignore-line
-
-        $version = InstalledVersions::getPrettyVersion('phpstan/phpstan') ?? InstalledVersions::getPrettyVersion('phpstan/phpstan-src');
-        if ($version !== null && version_compare($version, '2.1.12', '>=')) {
-            $nodeScopeResolver = new NodeScopeResolver( // @phpstan-ignore-line
-                reflectionProvider: $reflectionProvider,
-                initializerExprTypeResolver: $container->getByType(InitializerExprTypeResolver::class),
-                reflector: $container->getService('betterReflectionReflector'), // @phpstan-ignore-line
-                classReflectionExtensionRegistryProvider: $container->getByType(ClassReflectionExtensionRegistryProvider::class),
-                parameterOutTypeExtensionProvider: $container->getByType(ParameterOutTypeExtensionProvider::class),
-                parser: $container->getService('defaultAnalysisParser'), // @phpstan-ignore-line
-                fileTypeMapper: $container->getByType(FileTypeMapper::class),
-                stubPhpDocProvider: $container->getByType(StubPhpDocProvider::class),
-                phpVersion: $container->getByType(PhpVersion::class),
-                signatureMapProvider: $container->getByType(SignatureMapProvider::class),
-                deprecationProvider: $container->getByType(DeprecationProvider::class),
-                attributeReflectionFactory: $container->getByType(AttributeReflectionFactory::class),
-                phpDocInheritanceResolver: $container->getByType(PhpDocInheritanceResolver::class),
-                fileHelper: $container->getByType(FileHelper::class),
-                typeSpecifier: $typeSpecifier, // @phpstan-ignore-line
-                dynamicThrowTypeExtensionProvider: $container->getByType(DynamicThrowTypeExtensionProvider::class),
-                readWritePropertiesExtensionProvider: $container->getByType(ReadWritePropertiesExtensionProvider::class),
-                parameterClosureTypeExtensionProvider: $container->getByType(ParameterClosureTypeExtensionProvider::class),
-                scopeFactory: $scopeFactory,
-                polluteScopeWithLoopInitialAssignments: false,
-                polluteScopeWithAlwaysIterableForeach: true,
-                polluteScopeWithBlock: true, // @phpstan-ignore-line
-                earlyTerminatingMethodCalls: [],
-                earlyTerminatingFunctionCalls: [],
-                universalObjectCratesClasses: [], // @phpstan-ignore-line
-                implicitThrows: true,
-                treatPhpDocTypesAsCertain: true,
-                narrowMethodScopeFromConstructor: true,
-            );
-        } elseif ($version !== null && version_compare($version, '2.1.3', '>=')) {
-            $nodeScopeResolver = new NodeScopeResolver( // @phpstan-ignore-line
-                $reflectionProvider,
-                $container->getByType(InitializerExprTypeResolver::class),
-                $container->getService('betterReflectionReflector'), // @phpstan-ignore-line
-                $container->getByType(ClassReflectionExtensionRegistryProvider::class),
-                $container->getByType(ParameterOutTypeExtensionProvider::class),
-                $container->getService('defaultAnalysisParser'), // @phpstan-ignore-line
-                $container->getByType(FileTypeMapper::class),
-                $container->getByType(StubPhpDocProvider::class),
-                $container->getByType(PhpVersion::class),
-                $container->getByType(SignatureMapProvider::class),
-                $container->getByType(AttributeReflectionFactory::class),
-                $container->getByType(PhpDocInheritanceResolver::class),
-                $container->getByType(FileHelper::class),
-                $typeSpecifier, // @phpstan-ignore-line
-                $container->getByType(DynamicThrowTypeExtensionProvider::class),
-                $container->getByType(ReadWritePropertiesExtensionProvider::class),
-                $container->getByType(ParameterClosureTypeExtensionProvider::class),
-                $scopeFactory,
-                false,
-                true,
-                true, // @phpstan-ignore-line
-                [],
-                [],
-                [], // @phpstan-ignore-line
-                true,
-                true,
-            );
-        } elseif ($version !== null && version_compare($version, '2.0.0', '>=')) {
-            $nodeScopeResolver = new NodeScopeResolver( // @phpstan-ignore-line
-                $reflectionProvider,
-                $container->getByType(InitializerExprTypeResolver::class),
-                $container->getService('betterReflectionReflector'), // @phpstan-ignore-line
-                $container->getByType(ClassReflectionExtensionRegistryProvider::class),
-                $container->getByType(ParameterOutTypeExtensionProvider::class),
-                $container->getService('defaultAnalysisParser'), // @phpstan-ignore-line
-                $container->getByType(FileTypeMapper::class),
-                $container->getByType(StubPhpDocProvider::class),
-                $container->getByType(PhpVersion::class),
-                $container->getByType(SignatureMapProvider::class),
-                $container->getByType(PhpDocInheritanceResolver::class),
-                $container->getByType(FileHelper::class),
-                $typeSpecifier, // @phpstan-ignore-line
-                $container->getByType(DynamicThrowTypeExtensionProvider::class),
-                $container->getByType(ReadWritePropertiesExtensionProvider::class),
-                $container->getByType(ParameterClosureTypeExtensionProvider::class),
-                $scopeFactory,
-                false,
-                true,
-                true, // @phpstan-ignore-line
-                [],
-                [],
-                [], // @phpstan-ignore-line
-                true,
-                true,
-            );
-        } else {
-            $nodeScopeResolver = new NodeScopeResolver(
-                $reflectionProvider,
-                $container->getByType(InitializerExprTypeResolver::class),
-                $container->getService('betterReflectionReflector'), // @phpstan-ignore-line
-                $container->getByType(ClassReflectionExtensionRegistryProvider::class),
-                $container->getByType(ParameterOutTypeExtensionProvider::class),
-                $container->getService('defaultAnalysisParser'), // @phpstan-ignore-line
-                $container->getByType(FileTypeMapper::class),
-                $container->getByType(StubPhpDocProvider::class),
-                $container->getByType(PhpVersion::class),
-                $container->getByType(SignatureMapProvider::class),
-                $container->getByType(PhpDocInheritanceResolver::class),
-                $container->getByType(FileHelper::class),
-                $typeSpecifier, // @phpstan-ignore-line
-                $container->getByType(DynamicThrowTypeExtensionProvider::class),
-                $container->getByType(ReadWritePropertiesExtensionProvider::class),
-                $container->getByType(ParameterClosureTypeExtensionProvider::class),
-                $scopeFactory,
-                false,
-                true,
-                [],
-                [],
-                [],
-                true,
-                true,
-                false,
-                true,
-                false,
-                false,
-            );
-        }
-
-        try {
-            $fileAnalyser = new FileAnalyser(
-                scopeFactory: $scopeFactory,
-                nodeScopeResolver: $nodeScopeResolver,
-                parser: $container->getService('defaultAnalysisParser'), // @phpstan-ignore-line
-                dependencyResolver: $container->getByType(DependencyResolver::class),
-                ignoreErrorExtensionProvider: $container->getByType(IgnoreErrorExtensionProvider::class),
-                ruleErrorTransformer: new RuleErrorTransformer,
-                localIgnoresProcessor: $container->getByType(LocalIgnoresProcessor::class),
-            );
-        } catch (\Throwable $e) {
-            $fileAnalyser = new FileAnalyser(
-                scopeFactory: $scopeFactory,
-                nodeScopeResolver: $nodeScopeResolver,
-                parser: $container->getService('defaultAnalysisParser'), // @phpstan-ignore-line
-                dependencyResolver: $container->getByType(DependencyResolver::class),
-                ruleErrorTransformer: new RuleErrorTransformer,
-                localIgnoresProcessor: $container->getByType(LocalIgnoresProcessor::class),
-            );
-        }
-
-        return new Analyser($fileAnalyser, $ruleRegistry, $collectorRegistry, $nodeScopeResolver, 9_999_999_999_999);
+        return new Analyser(
+            $fileAnalyser,
+            $ruleRegistry,
+            $collectorRegistry,
+            $nodeScopeResolver,
+            9_999_999_999_999
+        );
     }
 }

--- a/src/PHPStanAnalyser.php
+++ b/src/PHPStanAnalyser.php
@@ -20,7 +20,7 @@ use PHPStan\Rules\Rule;
 final class PHPStanAnalyser
 {
     /**
-     * Creates an analyzer with the rules and collectors needed for type coverage.
+     * Creates an analyser with the rules and collectors needed for type coverage.
      *
      * @param  array<int, Rule>  $rules
      * @param  array<int, Collector<Node, mixed>>  $collectors

--- a/src/PHPStanAnalyser.php
+++ b/src/PHPStanAnalyser.php
@@ -58,33 +58,34 @@ final class PHPStanAnalyser
         $version = InstalledVersions::getPrettyVersion('phpstan/phpstan') ?? InstalledVersions::getPrettyVersion('phpstan/phpstan-src');
         if ($version !== null && version_compare($version, '2.1.12', '>=')) {
             $nodeScopeResolver = new NodeScopeResolver( // @phpstan-ignore-line
-                $reflectionProvider,
-                $container->getByType(InitializerExprTypeResolver::class),
-                $container->getService('betterReflectionReflector'), // @phpstan-ignore-line
-                $container->getByType(ClassReflectionExtensionRegistryProvider::class),
-                $container->getByType(ParameterOutTypeExtensionProvider::class),
-                $container->getService('defaultAnalysisParser'), // @phpstan-ignore-line
-                $container->getByType(FileTypeMapper::class),
-                $container->getByType(StubPhpDocProvider::class),
-                $container->getByType(PhpVersion::class),
-                $container->getByType(SignatureMapProvider::class),
-                $container->getByType(DeprecationProvider::class),
-                $container->getByType(AttributeReflectionFactory::class),
-                $container->getByType(PhpDocInheritanceResolver::class),
-                $container->getByType(FileHelper::class),
-                $typeSpecifier, // @phpstan-ignore-line
-                $container->getByType(DynamicThrowTypeExtensionProvider::class),
-                $container->getByType(ReadWritePropertiesExtensionProvider::class),
-                $container->getByType(ParameterClosureTypeExtensionProvider::class),
-                $scopeFactory,
-                false,
-                true,
-                true, // @phpstan-ignore-line
-                [],
-                [],
-                [], // @phpstan-ignore-line
-                true,
-                true,
+                reflectionProvider: $reflectionProvider,
+                initializerExprTypeResolver: $container->getByType(InitializerExprTypeResolver::class),
+                reflector: $container->getService('betterReflectionReflector'), // @phpstan-ignore-line
+                classReflectionExtensionRegistryProvider: $container->getByType(ClassReflectionExtensionRegistryProvider::class),
+                parameterOutTypeExtensionProvider: $container->getByType(ParameterOutTypeExtensionProvider::class),
+                parser: $container->getService('defaultAnalysisParser'), // @phpstan-ignore-line
+                fileTypeMapper: $container->getByType(FileTypeMapper::class),
+                stubPhpDocProvider: $container->getByType(StubPhpDocProvider::class),
+                phpVersion: $container->getByType(PhpVersion::class),
+                signatureMapProvider: $container->getByType(SignatureMapProvider::class),
+                deprecationProvider: $container->getByType(DeprecationProvider::class),
+                attributeReflectionFactory: $container->getByType(AttributeReflectionFactory::class),
+                phpDocInheritanceResolver: $container->getByType(PhpDocInheritanceResolver::class),
+                fileHelper: $container->getByType(FileHelper::class),
+                typeSpecifier: $typeSpecifier, // @phpstan-ignore-line
+                dynamicThrowTypeExtensionProvider: $container->getByType(DynamicThrowTypeExtensionProvider::class),
+                readWritePropertiesExtensionProvider: $container->getByType(ReadWritePropertiesExtensionProvider::class),
+                parameterClosureTypeExtensionProvider: $container->getByType(ParameterClosureTypeExtensionProvider::class),
+                scopeFactory: $scopeFactory,
+                polluteScopeWithLoopInitialAssignments: false,
+                polluteScopeWithAlwaysIterableForeach: true,
+                polluteScopeWithBlock: true, // @phpstan-ignore-line
+                earlyTerminatingMethodCalls: [],
+                earlyTerminatingFunctionCalls: [],
+                universalObjectCratesClasses: [], // @phpstan-ignore-line
+                implicitThrows: true,
+                treatPhpDocTypesAsCertain: true,
+                narrowMethodScopeFromConstructor: true,
             );
         } elseif ($version !== null && version_compare($version, '2.1.3', '>=')) {
             $nodeScopeResolver = new NodeScopeResolver( // @phpstan-ignore-line


### PR DESCRIPTION
Since [PHPStan 2.1.12](https://github.com/phpstan/phpstan/releases/tag/2.1.12) introduces an additional constructor parameter in NodeScopeResolver, this PR adjusts the constructor invocation for PHPStan ≥ 2.1.12.

![CleanShot 2025-04-16 at 17 14 55](https://github.com/user-attachments/assets/04260eb6-d0f5-40bd-a4e9-243e063bb87b)