### PR TITLE
Ignoring `*.blade.php` Files

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -120,7 +120,12 @@ class Plugin implements HandlesOriginalArguments
             $this->exit(1);
         }
 
-        $files = Finder::create()->in($source)->name('*.php')->files();
+        $files = Finder::create()
+            ->in($source)
+            ->name('*.php')
+            ->notName('*.blade.php')
+            ->files();
+
         $totals = [];
 
         $this->output->writeln(['']);


### PR DESCRIPTION
For libraries, such as [tallstackui/tallstackui](https://github.com/tallstackui/tallstackui), the source of the files is `src/` where we also have `*.blade.php` files, causing the analysis to pass through the `*.blade.php` files even if nothing is done. 

![CleanShot 2025-05-27 at 18 51 02](https://github.com/user-attachments/assets/c71c41ed-1d52-4246-9940-d4ba7af9c6ad)

With this PR, we ensure to skip `*.blade.php` files.