### PR TITLE
feat: add support for `--configuration` argument

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -119,7 +119,8 @@ class Plugin implements HandlesOriginalArguments
             }
         }
 
-        $source = ConfigurationSourceDetector::detect();
+        $configArg = current(array_filter($arguments, fn ($arg) => str_starts_with($arg, '--configuration=')));
+        $source = ConfigurationSourceDetector::detect($configArg ? [$configArg] : []);
 
         if ($source === []) {
             View::render('components.badge', [

--- a/src/Support/ConfigurationSourceDetector.php
+++ b/src/Support/ConfigurationSourceDetector.php
@@ -18,11 +18,12 @@ final class ConfigurationSourceDetector
     /**
      * Detects the "source" of the configuration.
      *
+     * @param  array<int, string>  $arguments
      * @return array<int, string>
      */
-    public static function detect(): array
+    public static function detect(array $arguments = []): array
     {
-        $cliConfiguration = (new Builder)->fromParameters([]);
+        $cliConfiguration = (new Builder)->fromParameters($arguments);
         $configurationFile = (new XmlConfigurationFileFinder)->find($cliConfiguration);
         $xmlConfiguration = DefaultConfiguration::create();
 


### PR DESCRIPTION
### Summary

This pull request introduces support for passing the --configuration argument to the Pest Type Coverage Plugin, enabling it to correctly detect and load custom PHPUnit configuration files.

Previously, the plugin always relied on default configuration discovery, ignoring the --configuration flag. This made it impossible to specify a custom XML configuration file when running Pest with type coverage enabled.

### What’s Changed

- `src/Plugin.php`
  -   Added logic to extract the `--configuration` argument (if present) from the CLI arguments.
  -  Passed the detected argument into `ConfigurationSourceDetector::detect()` for accurate configuration loading.

- `src/Support/ConfigurationSourceDetector.php`
  - Updated the `detect()` method to accept an optional `$arguments` array.
  - Adjusted the internal `Builder` initialization to use the provided arguments.
  
### Why This Matters

This enhancement improves compatibility with projects that use custom PHPUnit XML configuration paths, ensuring that type coverage detection respects all settings defined in those files (e.g., custom source directories, filters, or test suites).

It brings the behavior of the Pest Type Coverage Plugin in line with how PHPUnit and Pest natively handle CLI configuration flags

### Example Usage
```sh
./vendor/bin/pest --type-coverage --configuration=config/utils/phpunit.xml
```

The plugin now correctly reads and applies the configuration from the provided XML file.