### PR TITLE
Better Configuration Parsing

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -16,7 +16,6 @@ use Pest\TypeCoverage\Support\Cache;
 use Pest\TypeCoverage\Support\ConfigurationSourceDetector;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Finder\Finder;
 
 use function Termwind\render;
 use function Termwind\renderUsing;
@@ -119,10 +118,39 @@ class Plugin implements HandlesOriginalArguments
             }
         }
 
-        $configArg = current(array_filter($arguments, fn ($arg) => str_starts_with($arg, '--configuration=')));
-        $source = ConfigurationSourceDetector::detect($configArg ? [$configArg] : []);
+        // Normalize configuration argument to support: --configuration=, --configuration <file>, -c <file>, -c=<file>
+        $normalizedConfigArg = null;
+        foreach ($arguments as $index => $arg) {
+            if (str_starts_with($arg, '--configuration=')) {
+                $normalizedConfigArg = $arg;
+                break;
+            }
 
-        if ($source === []) {
+            if ($arg === '--configuration') {
+                $value = $arguments[$index + 1] ?? null;
+                if ($value !== null) {
+                    $normalizedConfigArg = '--configuration='.$value;
+                    break;
+                }
+            }
+
+            if ($arg === '-c') {
+                $value = $arguments[$index + 1] ?? null;
+                if ($value !== null) {
+                    $normalizedConfigArg = '--configuration='.$value;
+                    break;
+                }
+            }
+
+            if (str_starts_with($arg, '-c=')) {
+                $normalizedConfigArg = '--configuration='.substr($arg, 3);
+                break;
+            }
+        }
+
+        $files = ConfigurationSourceDetector::detect($normalizedConfigArg ? [$normalizedConfigArg] : []);
+
+        if ($files === []) {
             View::render('components.badge', [
                 'type' => 'ERROR',
                 'content' => 'No source section found. Did you forget to add a `source` section to your `phpunit.xml` file?',
@@ -131,16 +159,11 @@ class Plugin implements HandlesOriginalArguments
             $this->exit(1);
         }
 
-        $files = Finder::create()
-            ->in($source)
-            ->name('*.php')
-            ->notName('*.blade.php')
-            ->files();
-
-        $files = array_filter(
-            iterator_to_array($files),
-            fn (string $file): bool => ! str_contains(file_get_contents($file), 'trait '),
-        );
+        // Filter out traits
+        $files = array_values(array_filter(
+            $files,
+            static fn (string $file): bool => is_string($file) && is_file($file) && ! str_contains((string) file_get_contents($file), 'trait '),
+        ));
 
         $totals = [];
 
@@ -158,13 +181,13 @@ class Plugin implements HandlesOriginalArguments
         }
 
         if ($total > 1) {
-            $files = array_filter($files, static function ($file) use ($index, $total): bool {
-                return (crc32($file->getRealPath()) % $total) === ($index - 1);
-            });
+            $files = array_values(array_filter($files, static function (string $file) use ($index, $total): bool {
+                return (crc32((string) realpath($file)) % $total) === ($index - 1);
+            }));
         }
 
         Analyser::analyse(
-            array_keys($files),
+            $files,
             function (Result $result) use (&$totals): void {
                 $path = str_replace(TestSuite::getInstance()->rootPath.DIRECTORY_SEPARATOR, '', $result->file);
                 $uncoveredLines = [];

--- a/src/Support/ConfigurationSourceDetector.php
+++ b/src/Support/ConfigurationSourceDetector.php
@@ -6,9 +6,11 @@ namespace Pest\TypeCoverage\Support;
 
 use PHPUnit\TextUI\CliArguments\Builder;
 use PHPUnit\TextUI\CliArguments\XmlConfigurationFileFinder;
+use PHPUnit\TextUI\Configuration\File;
 use PHPUnit\TextUI\Configuration\FilterDirectory;
 use PHPUnit\TextUI\XmlConfiguration\DefaultConfiguration;
 use PHPUnit\TextUI\XmlConfiguration\Loader;
+use Symfony\Component\Finder\Finder;
 
 /**
  * @internal
@@ -23,17 +25,91 @@ final class ConfigurationSourceDetector
      */
     public static function detect(array $arguments = []): array
     {
-        $cliConfiguration = (new Builder)->fromParameters($arguments);
-        $configurationFile = (new XmlConfigurationFileFinder)->find($cliConfiguration);
+        // Try to resolve configuration file directly from provided arguments
+        $configurationFile = null;
+        foreach ($arguments as $index => $arg) {
+            if (str_starts_with($arg, '--configuration=')) {
+                $configurationFile = substr($arg, strlen('--configuration='));
+                break;
+            }
+            if ($arg === '--configuration') {
+                $configurationFile = $arguments[$index + 1] ?? null;
+                break;
+            }
+            if ($arg === '-c') {
+                $configurationFile = $arguments[$index + 1] ?? null;
+                break;
+            }
+        }
+
+        if (! is_string($configurationFile)) {
+            $cliConfiguration = (new Builder)->fromParameters($arguments);
+            $configurationFile = (new XmlConfigurationFileFinder)->find($cliConfiguration);
+        }
         $xmlConfiguration = DefaultConfiguration::create();
 
         if (is_string($configurationFile)) {
             $xmlConfiguration = (new Loader)->load($configurationFile);
         }
 
-        return array_map(
-            fn (FilterDirectory $directory): string => (string) realpath($directory->path()),
-            $xmlConfiguration->source()->includeDirectories()->asArray(),
-        );
+        $source = $xmlConfiguration->source();
+
+        $includeDirectories = array_values(array_filter(array_map(
+            fn (FilterDirectory $directory): string|false => realpath($directory->path()) ?: false,
+            $source->includeDirectories()->asArray(),
+        )));
+
+        $includeFiles = array_values(array_filter(array_map(
+            fn (File $file): string|false => realpath($file->path()) ?: false,
+            $source->includeFiles()->asArray(),
+        )));
+
+        $excludeDirectories = array_values(array_filter(array_map(
+            fn (FilterDirectory $directory): string|false => realpath($directory->path()) ?: false,
+            $source->excludeDirectories()->asArray(),
+        )));
+
+        $excludeFiles = array_values(array_filter(array_map(
+            fn (File $file): string|false => realpath($file->path()) ?: false,
+            $source->excludeFiles()->asArray(),
+        )));
+
+        // Build the list of PHP files from included directories (if any)
+        $filesFromDirectories = [];
+        if ($includeDirectories !== []) {
+            $finder = Finder::create()
+                ->in($includeDirectories)
+                ->name('*.php')
+                ->notName('*.blade.php')
+                ->files();
+
+            $filesFromDirectories = array_map(
+                static fn ($file): string => (string) realpath($file->getRealPath()),
+                iterator_to_array($finder)
+            );
+        }
+
+        // Merge with explicitly included files
+        $allIncluded = array_values(array_unique(array_merge($filesFromDirectories, $includeFiles)));
+
+        // Apply excludes
+        $allIncluded = array_values(array_filter($allIncluded, static function (string $path) use ($excludeDirectories, $excludeFiles): bool {
+            // Exclude explicit files
+            if (in_array($path, $excludeFiles, true)) {
+                return false;
+            }
+
+            // Exclude by directories
+            foreach ($excludeDirectories as $excludeDir) {
+                $prefix = rtrim($excludeDir, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
+                if (str_starts_with($path, $prefix)) {
+                    return false;
+                }
+            }
+
+            return true;
+        }));
+
+        return $allIncluded;
     }
 }

--- a/tests/Fixtures/phpunit.exclude.file.xml
+++ b/tests/Fixtures/phpunit.exclude.file.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd"
+         bootstrap="vendor/autoload.php">
+    <testsuites>
+        <testsuite name="default">
+            <directory suffix=".php">./tests</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory suffix=".php">./</directory>
+        </include>
+        <exclude>
+            <file>./Parameters.php</file>
+        </exclude>
+    </source>
+</phpunit>
+
+

--- a/tests/Fixtures/phpunit.include.file.xml
+++ b/tests/Fixtures/phpunit.include.file.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd"
+         bootstrap="vendor/autoload.php">
+    <testsuites>
+        <testsuite name="default">
+            <directory suffix=".php">./tests</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <file>./All.php</file>
+        </include>
+    </source>
+</phpunit>
+
+

--- a/tests/Support/ConfigurationSourceDetector.php
+++ b/tests/Support/ConfigurationSourceDetector.php
@@ -5,8 +5,34 @@ use Pest\TypeCoverage\Support\ConfigurationSourceDetector;
 it('detects the source of the application', function () {
     $sources = ConfigurationSourceDetector::detect();
 
-    expect($sources)->toBe([
-        realpath(__DIR__.'/../../src'),
-        realpath(__DIR__.'/../../tests/Fixtures'),
-    ]);
+    expect($sources)->toBeArray()
+        ->and($sources)->toContain(
+            realpath(__DIR__.'/../../src/Plugin.php'),
+            realpath(__DIR__.'/../../tests/Fixtures/All.php'),
+        );
+});
+
+it('supports --configuration=<file> and includes single file', function () {
+    $config = realpath(__DIR__.'/../Fixtures/phpunit.include.file.xml');
+    $sources = ConfigurationSourceDetector::detect(['--configuration='.$config]);
+
+    expect($sources)->toHaveCount(1)
+        ->and($sources)->toContain(realpath(__DIR__.'/../Fixtures/All.php'));
+});
+
+it('supports --configuration <file> and excludes files', function () {
+    $config = realpath(__DIR__.'/../Fixtures/phpunit.exclude.file.xml');
+    $sources = ConfigurationSourceDetector::detect(['--configuration', $config]);
+
+    expect($sources)->not->toContain(
+        realpath(__DIR__.'/../Fixtures/Parameters.php')
+    )->and($sources)->not->toBeEmpty();
+});
+
+it('supports -c <file>', function () {
+    $config = realpath(__DIR__.'/../Fixtures/phpunit.include.file.xml');
+    $sourcesShort = ConfigurationSourceDetector::detect(['-c', $config]);
+
+    expect($sourcesShort)->toHaveCount(1)
+        ->and($sourcesShort)->toContain(realpath(__DIR__.'/../Fixtures/All.php'));
 });


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [x] Bug Fix
- [x] New Feature

### Description:

This PR handles two related things: 

1. The `-c` and `--configuration` flags that the rest of Pest uses to pass a phpunit.xml file do not work. Only `--configuration=` works. This PR makes it such that both `-c` and `--configuration` work, with and without the `=`.
2. The configuration parsing does not support including individual files nor exclusions of files or directories. This PR enables all of those things. You can have a config that scans an entire directory except for these three files, you can have a config that only scans these two files, etc.
