### PR TITLE
fix: use serialize/unserialize for cache to prevent __set_state crashes

### DIFF
--- a/src/Support/Cache.php
+++ b/src/Support/Cache.php
@@ -15,7 +15,7 @@ final class Cache
     /**
      * The cache version.
      */
-    private const string CACHE_VERSION = 'v3';
+    private const string CACHE_VERSION = 'v4';
 
     /**
      * The cache instance.
@@ -138,7 +138,7 @@ final class Cache
 
             $cache[$fileHash] = $values;
 
-            $content = '<?php return '.var_export($cache, true).';';
+            $content = '<?php return unserialize('.var_export(serialize($cache), true).');';
 
             if (file_put_contents($filePath, $content) !== false) {
                 chmod($filePath, 0666);

--- a/tests/Support/Cache.php
+++ b/tests/Support/Cache.php
@@ -1,0 +1,41 @@
+<?php
+
+use Pest\TypeCoverage\Support\Cache;
+use PHPStan\Analyser\Error;
+
+beforeEach(function () {
+    $this->cache = Cache::instance();
+    $this->cache->flush();
+});
+
+afterEach(function () {
+    $this->cache->flush();
+});
+
+test('it persists and retrieves cached results', function () {
+    $file = __DIR__.'/../Fixtures/All.php';
+    $error = new Error('Test error', $file, 10);
+
+    $this->cache->persist($file, [$file, [$error], []]);
+
+    expect($this->cache->has($file))->toBeTrue()
+        ->and($this->cache->get($file))->toBeArray()
+        ->and($this->cache->get($file)[0])->toBe($file)
+        ->and($this->cache->get($file)[1])->toHaveCount(1)
+        ->and($this->cache->get($file)[1][0])->toBeInstanceOf(Error::class)
+        ->and($this->cache->get($file)[1][0]->getMessage())->toBe('Test error');
+});
+
+test('it persists and retrieves errors containing PhpParser node metadata', function () {
+    $file = __DIR__.'/../Fixtures/All.php';
+    $nodeName = new PhpParser\Node\Name('Tests\Fixtures\All');
+    $error = new Error('Type mismatch', $file, 10, metadata: ['type' => $nodeName]);
+
+    $this->cache->persist($file, [$file, [$error], []]);
+
+    $cached = $this->cache->get($file);
+
+    expect($cached[1])->toHaveCount(1)
+        ->and($cached[1][0])->toBeInstanceOf(Error::class)
+        ->and($cached[1][0]->getMessage())->toBe('Type mismatch');
+});


### PR DESCRIPTION
## Description

Fixes a crash when PHPStan `Error` objects contain `PhpParser\Node\Name` references in their metadata.

The cache system uses `var_export()` to persist analysis results. When errors include PhpParser node objects, `var_export()` generates `__set_state()` calls. Since `PhpParser\Node\Name` (nikic/php-parser v5) does not implement `__set_state()`, loading the cache crashes with:

```
Call to undefined method PhpParser\Node\Name::__set_state()
```

In Pokio fork mode, this causes `zend_mm_heap corrupted` and exits with code 1.

## Fix

- Replace `var_export($cache, true)` with `serialize()`/`unserialize()` on line 141 of `Cache.php`
- Bump cache version from `v3` to `v4` to invalidate existing corrupted cache files
- Add test that reproduces the crash with `PhpParser\Node\Name` in error metadata

## Steps to Reproduce

1. Have a Laravel project with PHPStan at level `max` with `bleedingEdge.neon`
2. Install `pestphp/pest-plugin-type-coverage` v4.0.3
3. Have code that triggers PHPStan errors where the error metadata includes `PhpParser\Node\Name` objects (e.g. type mismatch errors involving class references)
4. Run `pest --type-coverage`
5. First run may succeed (analysis + cache write)
6. Second run crashes when loading the cached `.temp/v3.php` file

Alternatively, the crash can occur on the first run in forked Pokio processes when cache is being written and read concurrently.