### PR TITLE
fix: use blocking flock to prevent cache file corruption in parallel runs

### DIFF
--- a/src/Support/Cache.php
+++ b/src/Support/Cache.php
@@ -162,27 +162,12 @@ final class Cache
             chmod($dirPath, 0755);
         }
 
-        if (! is_file($lockPath)) {
-            touch($lockPath);
-            chmod($lockPath, 0666);
-        }
-
         $lock = fopen($lockPath, 'c+');
         if ($lock === false) {
             return $callback();
         }
 
-        $attempts = 0;
-        while (! flock($lock, LOCK_EX | LOCK_NB) && $attempts < 100) {
-            usleep(1000);
-            $attempts++;
-        }
-
-        if ($attempts >= 100) {
-            fclose($lock);
-
-            return $callback();
-        }
+        flock($lock, LOCK_EX);
 
         try {
             return $callback();


### PR DESCRIPTION
**Base branch:** 4.x

## Description

`Cache::persist()` in `src/Support/Cache.php` performs a read-modify-write on a shared file (`.temp/v3.php`) from multiple pokio-forked processes. The `flock(LOCK_EX | LOCK_NB)` with 100 retries silently falls back to running **without any lock**, allowing concurrent writes that corrupt the `var_export()` output.

This results in intermittent `ParseError` crashes:

```
ParseError
syntax error, unexpected single-quoted string " => "
at vendor/pestphp/pest-plugin-type-coverage/.temp/v3.php
```

## Root cause

In `withinLock()`:

```php
$attempts = 0;
while (! flock($lock, LOCK_EX | LOCK_NB) && $attempts < 100) {
    usleep(1000);
    $attempts++;
}

if ($attempts >= 100) {
    fclose($lock);
    return $callback();  // ← runs WITHOUT the lock
}
```

## Suggested Fix

Replace the non-blocking retry loop with a blocking `flock($lock, LOCK_EX)` that waits until acquired. No silent fallback, no race.

## Reproduction

Minimal reproduction repo with a loop script that triggers the crash within a few attempts:
https://github.com/daniel-moh/pest-type-coverage-race-repro

## Workaround

We're currently running a workaround that disables forking to avoid the race:

```bash
__PEST_PLUGIN_ENV=testing php -d variables_order=EGPCS vendor/bin/pest --type-coverage --compact --min=50
```
