### PR TITLE
fix: make --no-cache truly bypass caching instead of just flushing

### DIFF
--- a/src/Analyser.php
+++ b/src/Analyser.php
@@ -20,7 +20,7 @@ final class Analyser
      * @param  array<int, string>  $files
      * @param  Closure(Result): void  $callback
      */
-    public static function analyse(array $files, Closure $postProcessedFile, Closure $onProcessedFile, Cache $cache): void
+    public static function analyse(array $files, Closure $postProcessedFile, Closure $onProcessedFile, ?Cache $cache): void
     {
         $testCase = new TestCaseForTypeCoverage('dummy');
 
@@ -31,7 +31,7 @@ final class Analyser
         $filesTouched = [];
 
         foreach ($files as $file) {
-            if ($cache->has($file)) {
+            if ($cache !== null && $cache->has($file)) {
                 [$file, $errors, $ignored] = $cache->get($file);
 
                 $result = Result::fromPHPStanErrors($file, $errors, $ignored);
@@ -95,7 +95,7 @@ final class Analyser
         TestCaseForTypeCoverage $testCase,
         Closure $postProcessedFile,
         Closure $onProcessedFile,
-        Cache $cache,
+        ?Cache $cache,
         bool $useAsync = true,
     ): void {
         $promises = [];
@@ -123,7 +123,7 @@ final class Analyser
                     $errors = array_values($errors);
                     $ignored = array_values($ignored);
 
-                    $cache->persist($file, [$file, $errors, $ignored]);
+                    $cache?->persist($file, [$file, $errors, $ignored]);
 
                     $result = Result::fromPHPStanErrors($file, $errors, $ignored);
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -65,7 +65,9 @@ class Plugin implements HandlesOriginalArguments
             return;
         }
 
-        if ($this->hasArgument('--no-cache', $arguments)) {
+        $noCache = $this->hasArgument('--no-cache', $arguments);
+
+        if ($noCache) {
             $this->cache->flush();
         }
 
@@ -234,7 +236,7 @@ class Plugin implements HandlesOriginalArguments
                 </div>
                 HTML);
             },
-            $this->cache,
+            $noCache ? null : $this->cache,
         );
 
         $coverage = array_sum($totals) / count($totals);


### PR DESCRIPTION
**Base branch:** 4.x

## Description

Currently `--no-cache` calls `Cache::flush()` and then continues to read from and write to the cache file during the run effectively rebuilding the cache from scratch rather than skipping it entirely.

This PR changes the behavior so that `--no-cache` flushes the existing cache AND skips all cache reads/writes during the run.

Alternatively, since changing `--no-cache` semantics could be considered a breaking change, a separate flag like `--without-cache` could be introduced instead, leaving `--no-cache` as-is. Happy to adjust the approach based on your preference.

## Changes

- **`Plugin.php`**: when `--no-cache` is set, passes `null` instead of `$this->cache` to `Analyser::analyse()`
- **`Analyser.php`**: accepts `?Cache`, skips `has()`/`get()` lookups and `persist()` writes when cache is null

## Context

Beyond the semantic question, the current `--no-cache` behavior still triggers concurrent writes to the shared `.temp/v3.php` file from parallel pokio forks. This can lead to cache file corruption via a race condition (#58). With true cache bypass, the shared file is never touched and the race is avoided entirely.
