### PR TITLE
fix: support both PHPStan 1.x and 2.x signatures in gatherAnalyserErrors()

### DIFF
--- a/src/TestCaseForTypeCoverage.php
+++ b/src/TestCaseForTypeCoverage.php
@@ -113,17 +113,45 @@ final class TestCaseForTypeCoverage extends RuleTestCase
                 $ruleErrors = $rule->processNode($node, $scope);
                 foreach ($ruleErrors as $ruleError) {
                     if ($this->ignored($ruleError)) {
-                        $this->ignoredErrors[] = $ruleErrorTransformer->transform($ruleError, $scope, [], $node);
+                        $this->ignoredErrors[] = $this->callTransform($ruleErrorTransformer, $ruleError, $scope, $nodeType, $node);
 
                         continue;
                     }
 
-                    $actualErrors[] = $ruleErrorTransformer->transform($ruleError, $scope, [], $node);
+                    $actualErrors[] = $this->callTransform($ruleErrorTransformer, $ruleError, $scope, $nodeType, $node);
                 }
             }
         }
 
         return $actualErrors;
+    }
+
+    /**
+     * Calls RuleErrorTransformer::transform() using the correct argument signature for the
+     * installed PHPStan version:
+     *   - PHPStan 1.x: transform(RuleError, Scope, string $nodeType, int $nodeLine)
+     *   - PHPStan 2.x: transform(RuleError, Scope, array $fileNodes, Node $node)
+     */
+    private function callTransform(
+        RuleErrorTransformer $transformer,
+        RuleError $ruleError,
+        Scope $scope,
+        string $nodeType,
+        CollectedDataNode $node,
+    ): Error {
+        static $isLegacySignature = null;
+        if ($isLegacySignature === null) {
+            $thirdParam = (new \ReflectionMethod($transformer, 'transform'))->getParameters()[2];
+            $isLegacySignature = (string) $thirdParam->getType() === 'string';
+        }
+
+        if ($isLegacySignature) {
+            // PHPStan 1.x: third arg is string $nodeType, fourth is int $nodeLine
+            return $transformer->transform($ruleError, $scope, $nodeType, $node->getLine()); // @phpstan-ignore-line
+        }
+
+        // PHPStan 2.x: third arg is array $fileNodes, fourth is Node $node
+        return $transformer->transform($ruleError, $scope, [], $node); // @phpstan-ignore-line
     }
 
     /**


### PR DESCRIPTION
### Problem

`gatherAnalyserErrors()` in `TestCaseForTypeCoverage` calls
`RuleErrorTransformer::transform()` with arguments that only match the PHPStan 2.x signature, causing a fatal `TypeError` for PHPStan 1.x users:

```
TypeError: PHPStan\Analyser\RuleErrorTransformer::transform(): Argument #3 ($nodeType)
must be of type string, array given, called in
.../pest-plugin-type-coverage/src/TestCaseForTypeCoverage.php on line 121
```

The two signatures differ between major versions:

| Version | Arg 3 | Arg 4 |
|---------|-------|-------|
| PHPStan 1.x | `string $nodeType` | `int $nodeLine` |
| PHPStan 2.x | `array $fileNodes` | `Node $node` |

The previous code passed `([], $node)` which satisfies PHPStan 2.x but throws a fatal `TypeError` on PHPStan 1.x because `$nodeType` must be `string`, not `array`.

### Fix

Add a private `callTransform()` helper that uses reflection (result cached via a `static` variable, so the check is done only once per process) to detect the installed PHPStan version's signature and dispatch to the correct call.

- PHPStan 1.x path: `transform($ruleError, $scope, $nodeType, $node->getLine())`
- PHPStan 2.x path: `transform($ruleError, $scope, [], $node)`

This fixes `--type-coverage` for PHPStan 1.x users without breaking PHPStan 2.x.